### PR TITLE
Add debug section to README for node-gyp errors.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,3 +22,16 @@ $ gatsby serve
 
 ## Accessing the CMS
 Follow the [Netlify CMS Quick Start Guide](https://www.netlifycms.org/docs/quick-start/#authentication) to set up authentication, and hosting.
+
+
+- - -
+
+### Debugging
+Windows users might encounter ```node-gyp``` errors when trying to npm install.
+To resolve, make sure that you have both Python 2.7 and the Visual C++ build environment installed.
+```
+npm config set python python2.7 
+npm install --global --production windows-build-tools
+```
+
+[Full details here](https://www.npmjs.com/package/node-gyp 'NPM node-gyp page')


### PR DESCRIPTION
The build was failing with npm node-gyp errors. Fix is to ensure that correct Python and Visual C++ build tools are installed. Suggest adding to README or a debug file as fix not apparent.