### PR TITLE
add post description field

### DIFF
--- a/src/pages/blog/2016-12-17-making-sense-of-the-scaas-new-flavor-wheel.md
+++ b/src/pages/blog/2016-12-17-making-sense-of-the-scaas-new-flavor-wheel.md
@@ -3,6 +3,7 @@ templateKey: blog-post
 path: /making-sense
 title: Making sense of the SCAA’s new Flavor Wheel
 date: 2016-12-17T15:04:10.000Z
+description: The Coffee Taster’s Flavor Wheel, the official resource used by coffee tasters, has been revised for the first time this year.
 ---
 ![flavor wheel](/img/flavor_wheel.jpg)
 

--- a/src/pages/blog/2017-01-04-a-beginners-guide-to-brewing-with-chemex.md
+++ b/src/pages/blog/2017-01-04-a-beginners-guide-to-brewing-with-chemex.md
@@ -3,6 +3,7 @@ templateKey: blog-post
 path: /brewing-chemex
 title: A beginners’ guide to brewing with Chemex
 date: 2017-01-04T15:04:10.000Z
+description: Brewing with a Chemex probably seems like a complicated, time-consuming ordeal, but once you get used to the process, it becomes a soothing ritual that's worth the effort every time.
 ---
 ![chemex](/img/chemex.jpg)
 

--- a/static/admin/config.yml
+++ b/static/admin/config.yml
@@ -16,6 +16,7 @@ collections:
       - {label: "Path", name: "path", widget: "string"}
       - {label: "Title", name: "title", widget: "string"}
       - {label: "Publish Date", name: "date", widget: "datetime"}
+      - {label: "Description", name: "description", widget: "text"}
       - {label: "Body", name: "body", widget: "markdown"}
 
   - name: "pages"


### PR DESCRIPTION
This is missing in the original Kaldi template, too. I should probably go do some updates on that as well.

This PR adds the field config and also re-adds the description content that was removed in recent edits (assuming that was not intentional).