### PR TITLE
Make CMS bundle path relative to allow relocating the CMS

### DIFF
--- a/static/admin/index.html
+++ b/static/admin/index.html
@@ -9,6 +9,6 @@
 </head>
 <body>
   <script>window.graphql = function () { return null; }</script>
-  <script src="/admin/cms.bundle.js"></script>
+  <script src="cms.bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
Fixes relocation errors like that reported at https://github.com/netlify/netlify-identity-widget/issues/107.