### PR TITLE
Correct path + remove unneeded graphql import

### DIFF
--- a/src/pages/blog/2016-12-17-making-sense-of-the-scaas-new-flavor-wheel.md
+++ b/src/pages/blog/2016-12-17-making-sense-of-the-scaas-new-flavor-wheel.md
@@ -1,6 +1,6 @@
 ---
 templateKey: blog-post
-path: making-sense
+path: /making-sense
 title: Making sense of the SCAA’s new Flavor Wheel
 date: 2016-12-17T15:04:10.000Z
 description: The Coffee Taster’s Flavor Wheel, the official resource used by coffee tasters, has been revised for the first time this year.

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,5 @@
 import React from 'react'
 import Link from 'gatsby-link'
-import graphql from 'graphql'
 
 export default class IndexPage extends React.Component {
   render() {

--- a/src/templates/about-page.js
+++ b/src/templates/about-page.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import graphql from 'graphql'
 import Content, { HTMLContent } from '../components/Content'
 
 export const AboutPageTemplate = ({ title, content, contentComponent }) => {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import graphql from 'graphql'
 import Helmet from 'react-helmet'
 import Content, { HTMLContent } from '../components/Content'
 
@@ -30,8 +29,8 @@ export const BlogPostTemplate = ({
   )
 }
 
-export default ({ data }) => {
-  const { markdownRemark: post } = data
+export default props => {
+  const { markdownRemark: post } = props.data
 
   return (
     <BlogPostTemplate

--- a/src/templates/product-page.js
+++ b/src/templates/product-page.js
@@ -1,5 +1,4 @@
 import React from 'react'
-import graphql from 'graphql'
 import Features from '../components/Features'
 import Testimonials from '../components/Testimonials'
 import Pricing from '../components/Pricing'


### PR DESCRIPTION
Removing passing in path surfaced a bug in the data where one of the paths was missing its forward slash. Gatsby adds to paths if you don't add it but because of the discrepancy, the query now failed because the path in the page object was different than the path in the markdown file.