### PR TITLE
Move blog-post filter to graphQL

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -14,7 +14,6 @@ export default class IndexPage extends React.Component {
             <h1 className="has-text-weight-bold is-size-2">Latest Stories</h1>
           </div>
           {posts
-            .filter(post => post.node.frontmatter.templateKey === 'blog-post')
             .map(({ node: post }) => (
               <div
                 className="content"
@@ -54,7 +53,10 @@ IndexPage.propTypes = {
 
 export const pageQuery = graphql`
   query IndexQuery {
-    allMarkdownRemark(sort: { order: DESC, fields: [frontmatter___date] }) {
+    allMarkdownRemark(
+      sort: { order: DESC, fields: [frontmatter___date] },
+      filter: { frontmatter: { templateKey: { eq: "blog-post" } }}
+    ) {
       edges {
         node {
           excerpt(pruneLength: 400)


### PR DESCRIPTION
I found filter `blog-post` enable to move graphQL.