### PR TITLE
Add netlify-cms to package.json now required by gatsby-plugin-netlify-cms

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "gatsby-source-filesystem": "^1.5.23",
     "gatsby-transformer-remark": "^1.7.33",
     "gatsby-transformer-sharp": "^1.6.21",
+    "netlify-cms": "^1.7.0",
     "lodash": "^4.17.5",
     "lodash-webpack-plugin": "^0.11.4",
     "prop-types": "^15.6.0",


### PR DESCRIPTION
As noted in issue https://github.com/AustinGreen/gatsby-starter-netlify-cms/issues/73 and https://github.com/gatsbyjs/gatsby/commit/35ccf1848da20a6d1fe5ffac65d04a0fe73b7114 the `gatsby-netlify-cms-plugin` now requires `netlify-cms` as a peer-dependency