### PR TITLE
Add sharp as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prop-types": "^15.6.0",
     "react": "^16.2.0",
     "react-helmet": "^5.2.0",
+    "sharp": "^0.20.5",
     "uuid": "^3.2.1"
   },
   "keywords": [


### PR DESCRIPTION
Without it, `gatsby develop` doesn't work after setting up the starter and running `npm install`

```
[benechols:~]$ gatsby develop
success delete html and css files from previous builds — 0.006 s
success open and validate gatsby-config.js — 0.004 s
success copy gatsby files — 0.027 s
error UNHANDLED EXCEPTION


  Error: Cannot find module 'sharp'

  - v8-compile-cache.js:159 require
    [codeforpms]/[v8-compile-cache]/v8-compile-cache.js:159:20

  - extend-node-type.js:35 Object.<anonymous>
    [codeforpms]/[gatsby-transformer-sharp]/extend-node-type.js:35:13

  - v8-compile-cache.js:178 Module._compile
    [codeforpms]/[v8-compile-cache]/v8-compile-cache.js:178:30

  - v8-compile-cache.js:159 require
    [codeforpms]/[v8-compile-cache]/v8-compile-cache.js:159:20

  - gatsby-node.js:16 Object.<anonymous>
    [codeforpms]/[gatsby-transformer-sharp]/gatsby-node.js:16:38

  - v8-compile-cache.js:178 Module._compile
    [codeforpms]/[v8-compile-cache]/v8-compile-cache.js:178:30

  - module.js:11 require
    internal/module.js:11:18

  - api-runner-node.js:87 runAPI
    [codeforpms]/[gatsby]/dist/utils/api-runner-node.js:87:20

  - api-runner-node.js:187
    [codeforpms]/[gatsby]/dist/utils/api-runner-node.js:187:33
```